### PR TITLE
Update layout_head.html.erb

### DIFF
--- a/public/views/layout_head.html.erb
+++ b/public/views/layout_head.html.erb
@@ -1,7 +1,7 @@
 <!-- aspace_sitemap -->
 <% if AppConfig.has_key?(:google_verification_meta_tag) %>
- <meta name="google-site-verification" content="<%= "#{AppConfig[:google_verification_meta_tag]}" %>">
+ <meta name="google-site-verification" content="<%= "#{AppConfig[:google_verification_meta_tag]}" %>" />
 <% end %>
 <% if AppConfig.has_key?(:bing_verification_meta_tag) %>
- <meta name="msvalidate.01" content="<%= "#{AppConfig[:bing_verification_meta_tag]}" %> />
+ <meta name="msvalidate.01" content="<%= "#{AppConfig[:bing_verification_meta_tag]}" %>" />
 <% end %>


### PR DESCRIPTION
The google meta tag was missing the self closing '/' and the bing tag was missing the closing quotation mark after the content attribute.
The google tag still worked for search console verification, but bing search console was not recognizing their tag without this change.