### PR TITLE
Fix typo in cron job type name (jon -> job)

### DIFF
--- a/backend/plugin_init.rb
+++ b/backend/plugin_init.rb
@@ -67,7 +67,7 @@ ArchivesSpaceService.settings.scheduler.cron(AppConfig[:aspace_sitemap_cron], :a
     "sitemap_baseurl" => AppConfig[:aspace_sitemap_default_base_url]
   }
 
-  sitemap_cron_job = JSONModel(:job).from_hash(:job_type => 'aspace_sitemap_jon',
+  sitemap_cron_job = JSONModel(:job).from_hash(:job_type => 'aspace_sitemap_job',
                                      :job => sitemap_job,
                                      :job_params =>  ASUtils.to_json(nil) )
   


### PR DESCRIPTION
The job_type value in the cron job definition contained a typo ('aspace_sitemap_jon' instead of 'aspace_sitemap_job'), causing 
the automated weekly cron job to silently fail. Manually triggered jobs were unaffected. This fixes the typo so the cron job fires 
as expected. Discovered while testing the plugin on ASpace 3.3.1.