### PR TITLE
Fix undefined sitemap_types variable in cron job

### DIFF
--- a/backend/plugin_init.rb
+++ b/backend/plugin_init.rb
@@ -58,7 +58,7 @@ ArchivesSpaceService.settings.scheduler.cron(AppConfig[:aspace_sitemap_cron], :a
     "format" => "zip",
     "job_type" => "aspace_sitemap_job",
     "jsonmodel_type" => "aspace_sitemap_job",
-    "sitemap_types" =>  sitemap_types,
+    "sitemap_types" => AppConfig[:allowed_sitemap_types_hash].keys,
     "sitemap_refresh_freq" => AppConfig[:aspace_sitemap_default_frequency],
     "sitemap_use_filesys" => AppConfig[:aspace_sitemap_use_filesystem],
     "sitemap_limit" => AppConfig[:aspace_sitemap_default_limit].to_s,


### PR DESCRIPTION
Hello!

The cron job block in backend/plugin_init.rb referenced a variable called `sitemap_types` that was never defined, causing the automated weekly cron job to fail with: undefined local variable or method `sitemap_types' for main:Object. The fix replaces the undefined variable with `AppConfig[:allowed_sitemap_types_hash].keys`, which reads the list of allowed object types directly from the plugin's config.

Discovered while testing on ASpace 3.3.1.